### PR TITLE
アカウント画面のタスクタブでカテゴリーごとの達成率を表示する

### DIFF
--- a/lib/constant/text_source.dart
+++ b/lib/constant/text_source.dart
@@ -75,6 +75,8 @@ const exerciseTx = '運動';
 const sleepTx = '睡眠';
 const workTx = '仕事';
 
+const incompleteTx = '未達成';
+
 // タスク関連
 const titleTx = 'タイトル';
 const categoryTx = 'カテゴリー';

--- a/lib/constant/themes/text_styles.dart
+++ b/lib/constant/themes/text_styles.dart
@@ -48,4 +48,9 @@ class TextStyles {
     fontSize: 14,
     fontWeight: FontWeight.w500,
   );
+  static const pieChartTextStyle = TextStyle(
+    color: textMainColor,
+    fontSize: 12,
+    fontWeight: FontWeight.bold,
+  );
 }

--- a/lib/model/enum/category.dart
+++ b/lib/model/enum/category.dart
@@ -28,6 +28,19 @@ Color categoryColor(Category category) {
   }
 }
 
+Color categoryColor2(Category category) {
+  switch (category) {
+    case Category.all:
+      return sandwispColor2;
+    case Category.exercise:
+      return yellowGreenColor2;
+    case Category.sleep:
+      return mantisColor2;
+    case Category.work:
+      return appleColor2;
+  }
+}
+
 class CategoryEnumConverter implements JsonConverter<Category?, String?> {
   const CategoryEnumConverter();
 

--- a/lib/model/src/pie_chart_sector.dart
+++ b/lib/model/src/pie_chart_sector.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class PieChartSector {
+  final Color color;
+  final double value;
+  final String title;
+  final TextStyle? titleStyle;
+
+  PieChartSector({
+    required this.color,
+    required this.value,
+    required this.title,
+    required this.titleStyle,
+  });
+}

--- a/lib/view/account_page/components/account_tabs_contents.dart
+++ b/lib/view/account_page/components/account_tabs_contents.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:serene_track/constant/text_source.dart';
 import 'package:serene_track/view/account_page/sleep_tab/sleep_tab.dart';
 import 'package:serene_track/view/account_page/steps_tab/steps_tab.dart';
+import 'package:serene_track/view/account_page/task_tab/task_tab.dart';
 
 class AccountTabsContents extends StatelessWidget {
   const AccountTabsContents({super.key});
@@ -10,9 +10,7 @@ class AccountTabsContents extends StatelessWidget {
   Widget build(BuildContext context) {
     return const TabBarView(
       children: [
-        Center(
-          child: Text(taskTx),
-        ),
+        TaskTab(),
         StepsTab(),
         SleepTab(),
       ],

--- a/lib/view/account_page/steps_tab/before_integration_content.dart
+++ b/lib/view/account_page/steps_tab/before_integration_content.dart
@@ -8,22 +8,28 @@ class BeforeIntegrationContent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: ElevatedButton(
-        style: ElevatedButton.styleFrom(
-          elevation: 0,
-          padding: const EdgeInsets.symmetric(horizontal: 16),
-          side: const BorderSide(
-            color: healthCareAppColor,
+    final screenHeight = MediaQuery.of(context).size.height;
+    return Column(
+      children: [
+        SizedBox(height: screenHeight * 0.2),
+        Center(
+          child: ElevatedButton(
+            style: ElevatedButton.styleFrom(
+              elevation: 0,
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              side: const BorderSide(
+                color: healthCareAppColor,
+              ),
+              foregroundColor: healthCareAppColor,
+              backgroundColor: backGroundColor,
+            ),
+            onPressed: () {
+              context.push(HealthCareAppIntegrationPage.routeLocation);
+            },
+            child: const Text('ヘルスケアと連携する'),
           ),
-          foregroundColor: healthCareAppColor,
-          backgroundColor: backGroundColor,
         ),
-        onPressed: () {
-          context.push(HealthCareAppIntegrationPage.routeLocation);
-        },
-        child: const Text('ヘルスケアと連携する'),
-      ),
+      ],
     );
   }
 }

--- a/lib/view/account_page/task_tab/components/custom_pie_chart.dart
+++ b/lib/view/account_page/task_tab/components/custom_pie_chart.dart
@@ -1,0 +1,73 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:serene_track/model/src/pie_chart_sector.dart';
+import 'package:serene_track/view/account_page/task_tab/provider/task_tab_notifier.dart';
+
+class CustomPieChart extends ConsumerWidget {
+  const CustomPieChart({
+    super.key,
+    required this.sectors,
+  });
+
+  final List<PieChartSector> sectors;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final touchedSectionIndex =
+        ref.watch(taskTabProvider.select((value) => value.touchedSectionIndex));
+    List<PieChartSectionData> chartSections(List<PieChartSector> sectors) {
+      final List<PieChartSectionData> list = [];
+      for (int i = 0; i < sectors.length; i++) {
+        final sector = sectors[i];
+        final data = PieChartSectionData(
+          color: sector.color,
+          value: sector.value,
+          // title: '${sector.value.toString()}%',
+          // titleStyle: sector.titleStyle,
+          showTitle: false,
+          radius: touchedSectionIndex == i ? 48.0 : 40.0,
+          badgeWidget: Transform.rotate(
+            angle: 90 * 3.2 / 180,
+            child: Text(
+              '${sector.value.toString()}%',
+              style: sector.titleStyle,
+            ),
+          ),
+        );
+        list.add(data);
+      }
+      return list;
+    }
+
+    return SizedBox(
+      height: 200,
+      width: 200,
+      child: Transform.rotate(
+        angle: -90 * 3.2 / 180,
+        child: PieChart(
+          PieChartData(
+            sections: chartSections(sectors),
+            centerSpaceRadius: 32.0,
+            pieTouchData: PieTouchData(
+              touchCallback: (FlTouchEvent e, PieTouchResponse? r) {
+                if (r != null && r.touchedSection != null) {
+                  ref.read(taskTabProvider.notifier).setTouchedSectionIndex(
+                      r.touchedSection!.touchedSectionIndex);
+                }
+              },
+              mouseCursorResolver: (FlTouchEvent e, PieTouchResponse? r) {
+                if (r != null &&
+                    r.touchedSection != null &&
+                    r.touchedSection!.touchedSectionIndex != -1) {
+                  return SystemMouseCursors.click;
+                }
+                return SystemMouseCursors.basic;
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view/account_page/task_tab/components/grid_pie_charts.dart
+++ b/lib/view/account_page/task_tab/components/grid_pie_charts.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:serene_track/constant/text_source.dart';
+import 'package:serene_track/constant/themes/text_styles.dart';
+import 'package:serene_track/view/account_page/task_tab/components/custom_pie_chart.dart';
+import 'package:serene_track/view/account_page/task_tab/components/sector_container.dart';
+import 'package:serene_track/view/account_page/task_tab/components/task_add_promotion.dart';
+import 'package:serene_track/view/account_page/task_tab/provider/task_tab_notifier.dart';
+
+class GridPieCharts extends ConsumerStatefulWidget {
+  const GridPieCharts({super.key});
+
+  @override
+  ConsumerState<GridPieCharts> createState() => GridPieChartsState();
+}
+
+class GridPieChartsState extends ConsumerState<GridPieCharts> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      ref.read(taskTabProvider.notifier).getSectors();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final screenHeight = MediaQuery.of(context).size.height;
+    final sectors =
+        ref.watch(taskTabProvider.select((value) => value.sectors)).toList();
+    if (sectors.isEmpty) {
+      return Column(
+        children: [
+          SizedBox(
+            height: screenHeight * 0.2,
+          ),
+          const TaskAddPromotion(),
+        ],
+      );
+    }
+
+    return SizedBox(
+      height: screenHeight * 0.94,
+      child: GridView.count(
+        crossAxisCount: 2,
+        children: List.generate(
+          4,
+          (index) {
+            return Center(
+              child: Stack(
+                children: [
+                  Positioned(
+                    top: 2,
+                    left: 10,
+                    child: SectorContainer(
+                      pieChartSector: sectors[index],
+                    ),
+                  ),
+                  Positioned(
+                    top: 4,
+                    left: 1,
+                    child: CustomPieChart(
+                      sectors: sectors[index],
+                    ),
+                  ),
+                  Positioned(
+                    top: 94,
+                    left: sectors[index][0].title == allTx ? 80 : 86,
+                    child: Text(
+                      sectors[index][0].title,
+                      style: TextStyles.accountHeaderBoldTextStyle,
+                    ),
+                  ),
+                ],
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view/account_page/task_tab/components/sector_container.dart
+++ b/lib/view/account_page/task_tab/components/sector_container.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/cupertino.dart';
+import 'package:serene_track/model/src/pie_chart_sector.dart';
+
+class SectorContainer extends StatelessWidget {
+  const SectorContainer({
+    super.key,
+    required this.pieChartSector,
+  });
+
+  final List<PieChartSector> pieChartSector;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 80,
+      width: 80,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            children: [
+              Container(
+                width: 10,
+                height: 10,
+                color: pieChartSector[0].color,
+              ),
+              const SizedBox(width: 8),
+              Text(
+                pieChartSector[0].title,
+                style: const TextStyle(
+                  fontSize: 12,
+                ),
+              ),
+            ],
+          ),
+          Row(
+            children: [
+              Container(
+                width: 10,
+                height: 10,
+                color: pieChartSector[1].color,
+              ),
+              const SizedBox(width: 8),
+              Text(
+                pieChartSector[1].title,
+                style: const TextStyle(
+                  fontSize: 12,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/view/account_page/task_tab/components/task_add_promotion.dart
+++ b/lib/view/account_page/task_tab/components/task_add_promotion.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:serene_track/constant/colors.dart';
+import 'package:serene_track/view/todo_page/todo_page.dart';
+
+class TaskAddPromotion extends StatelessWidget {
+  const TaskAddPromotion({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: ElevatedButton(
+        style: ElevatedButton.styleFrom(
+          elevation: 0,
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          side: const BorderSide(
+            color: appleColor,
+          ),
+          foregroundColor: appleColor,
+          backgroundColor: backGroundColor,
+        ),
+        onPressed: () {
+          context.go(TodoPage.routeLocation);
+        },
+        child: const Text('タスクを追加する'),
+      ),
+    );
+  }
+}

--- a/lib/view/account_page/task_tab/provider/task_tab_notifier.dart
+++ b/lib/view/account_page/task_tab/provider/task_tab_notifier.dart
@@ -1,0 +1,157 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:serene_track/constant/colors.dart';
+import 'package:serene_track/constant/text_source.dart';
+import 'package:serene_track/constant/themes/text_styles.dart';
+import 'package:serene_track/controllers/global/todo_notifier.dart';
+import 'package:serene_track/model/enum/category.dart';
+import 'package:serene_track/model/src/pie_chart_sector.dart';
+import 'package:serene_track/model/src/todo.dart';
+
+part 'task_tab_notifier.freezed.dart';
+
+@freezed
+class TaskTabState with _$TaskTabState {
+  factory TaskTabState({
+    @Default([]) List<List<PieChartSector>> sectors,
+    @Default([]) List<PieChartSector> allTodoSectors,
+    @Default([]) List<PieChartSector> exerciseTodoSectors,
+    @Default([]) List<PieChartSector> sleepTodoSectors,
+    @Default([]) List<PieChartSector> workTodoSectors,
+    @Default(-1) int touchedSectionIndex,
+  }) = _TaskTabState;
+  TaskTabState._();
+}
+
+final taskTabProvider =
+    StateNotifierProvider<TaskTabStateController, TaskTabState>((ref) {
+  final todos = ref.watch(todoProvider.select((value) => value.todos));
+  return TaskTabStateController(todos: todos);
+});
+
+class TaskTabStateController extends StateNotifier<TaskTabState> {
+  TaskTabStateController({
+    required todos,
+  })  : _todos = todos,
+        super(TaskTabState()) {
+    _init();
+  }
+
+  final List<Todo> _todos;
+
+  Future<void> _init() async {
+    state = state.copyWith(touchedSectionIndex: -1);
+    getSectors();
+  }
+
+  void getSectors() {
+    final exerciseTodos =
+        _todos.where((value) => value.categoryId == Category.exercise).toList();
+    final sleepTodos =
+        _todos.where((value) => value.categoryId == Category.sleep).toList();
+    final workTodos =
+        _todos.where((value) => value.categoryId == Category.work).toList();
+    final allTodoCompletions =
+        _todos.where((value) => value.complete == true).toList();
+    final exerciseTodoCompletions =
+        exerciseTodos.where((value) => value.complete == true).toList();
+    final sleepTodoCompletions =
+        sleepTodos.where((value) => value.complete == true).toList();
+    final workTodoCompletions =
+        workTodos.where((value) => value.complete == true).toList();
+    final allTodoCompletionRate = double.parse(
+      (allTodoCompletions.length / _todos.length).toStringAsFixed(1),
+    );
+    final exerciseTodoCompletionRate = double.parse(
+      (exerciseTodoCompletions.length / exerciseTodos.length)
+          .toStringAsFixed(1),
+    );
+    final sleepTodoCompletionRate = double.parse(
+      (sleepTodoCompletions.length / sleepTodos.length).toStringAsFixed(1),
+    );
+    final workTodoCompletionRate = double.parse(
+      (workTodoCompletions.length / workTodos.length).toStringAsFixed(1),
+    );
+    final allTodoSectors = [
+      PieChartSector(
+        color: categoryColor(Category.all),
+        value: allTodoCompletionRate * 100,
+        title: allTx,
+        titleStyle: TextStyles.pieChartTextStyle,
+      ),
+      PieChartSector(
+        color: lightGreyColor,
+        value: 100 - (allTodoCompletionRate * 100),
+        title: incompleteTx,
+        titleStyle: TextStyles.pieChartTextStyle.copyWith(
+          color: backGroundColor,
+        ),
+      ),
+    ];
+    final exerciseTodoSectors = [
+      PieChartSector(
+        color: categoryColor(Category.exercise),
+        value: exerciseTodoCompletionRate * 100,
+        title: exerciseTx,
+        titleStyle: TextStyles.pieChartTextStyle,
+      ),
+      PieChartSector(
+        color: lightGreyColor,
+        value: 100 - (exerciseTodoCompletionRate * 100),
+        title: incompleteTx,
+        titleStyle: TextStyles.pieChartTextStyle.copyWith(
+          color: backGroundColor,
+        ),
+      ),
+    ];
+    final sleepTodoSectors = [
+      PieChartSector(
+        color: categoryColor(Category.sleep),
+        value: sleepTodoCompletionRate * 100,
+        title: sleepTx,
+        titleStyle: TextStyles.pieChartTextStyle,
+      ),
+      PieChartSector(
+        color: lightGreyColor,
+        value: 100 - (sleepTodoCompletionRate * 100),
+        title: incompleteTx,
+        titleStyle: TextStyles.pieChartTextStyle.copyWith(
+          color: backGroundColor,
+        ),
+      ),
+    ];
+    final workTodoSectors = [
+      PieChartSector(
+        color: categoryColor(Category.work),
+        value: workTodoCompletionRate * 100,
+        title: workTx,
+        titleStyle: TextStyles.pieChartTextStyle,
+      ),
+      PieChartSector(
+        color: lightGreyColor,
+        value: 100 - (workTodoCompletionRate * 100),
+        title: incompleteTx,
+        titleStyle: TextStyles.pieChartTextStyle.copyWith(
+          color: backGroundColor,
+        ),
+      ),
+    ];
+    final sectors = [
+      allTodoSectors,
+      exerciseTodoSectors,
+      sleepTodoSectors,
+      workTodoSectors,
+    ];
+    state = state.copyWith(
+      allTodoSectors: allTodoSectors,
+      exerciseTodoSectors: exerciseTodoSectors,
+      sleepTodoSectors: sleepTodoSectors,
+      workTodoSectors: workTodoSectors,
+      sectors: sectors,
+    );
+  }
+
+  void setTouchedSectionIndex(int touchedSectionIndex) {
+    state = state.copyWith(touchedSectionIndex: touchedSectionIndex);
+  }
+}

--- a/lib/view/account_page/task_tab/provider/task_tab_notifier.freezed.dart
+++ b/lib/view/account_page/task_tab/provider/task_tab_notifier.freezed.dart
@@ -1,0 +1,296 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'task_tab_notifier.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$TaskTabState {
+  List<List<PieChartSector>> get sectors => throw _privateConstructorUsedError;
+  List<PieChartSector> get allTodoSectors => throw _privateConstructorUsedError;
+  List<PieChartSector> get exerciseTodoSectors =>
+      throw _privateConstructorUsedError;
+  List<PieChartSector> get sleepTodoSectors =>
+      throw _privateConstructorUsedError;
+  List<PieChartSector> get workTodoSectors =>
+      throw _privateConstructorUsedError;
+  int get touchedSectionIndex => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $TaskTabStateCopyWith<TaskTabState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $TaskTabStateCopyWith<$Res> {
+  factory $TaskTabStateCopyWith(
+          TaskTabState value, $Res Function(TaskTabState) then) =
+      _$TaskTabStateCopyWithImpl<$Res, TaskTabState>;
+  @useResult
+  $Res call(
+      {List<List<PieChartSector>> sectors,
+      List<PieChartSector> allTodoSectors,
+      List<PieChartSector> exerciseTodoSectors,
+      List<PieChartSector> sleepTodoSectors,
+      List<PieChartSector> workTodoSectors,
+      int touchedSectionIndex});
+}
+
+/// @nodoc
+class _$TaskTabStateCopyWithImpl<$Res, $Val extends TaskTabState>
+    implements $TaskTabStateCopyWith<$Res> {
+  _$TaskTabStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? sectors = null,
+    Object? allTodoSectors = null,
+    Object? exerciseTodoSectors = null,
+    Object? sleepTodoSectors = null,
+    Object? workTodoSectors = null,
+    Object? touchedSectionIndex = null,
+  }) {
+    return _then(_value.copyWith(
+      sectors: null == sectors
+          ? _value.sectors
+          : sectors // ignore: cast_nullable_to_non_nullable
+              as List<List<PieChartSector>>,
+      allTodoSectors: null == allTodoSectors
+          ? _value.allTodoSectors
+          : allTodoSectors // ignore: cast_nullable_to_non_nullable
+              as List<PieChartSector>,
+      exerciseTodoSectors: null == exerciseTodoSectors
+          ? _value.exerciseTodoSectors
+          : exerciseTodoSectors // ignore: cast_nullable_to_non_nullable
+              as List<PieChartSector>,
+      sleepTodoSectors: null == sleepTodoSectors
+          ? _value.sleepTodoSectors
+          : sleepTodoSectors // ignore: cast_nullable_to_non_nullable
+              as List<PieChartSector>,
+      workTodoSectors: null == workTodoSectors
+          ? _value.workTodoSectors
+          : workTodoSectors // ignore: cast_nullable_to_non_nullable
+              as List<PieChartSector>,
+      touchedSectionIndex: null == touchedSectionIndex
+          ? _value.touchedSectionIndex
+          : touchedSectionIndex // ignore: cast_nullable_to_non_nullable
+              as int,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$TaskTabStateImplCopyWith<$Res>
+    implements $TaskTabStateCopyWith<$Res> {
+  factory _$$TaskTabStateImplCopyWith(
+          _$TaskTabStateImpl value, $Res Function(_$TaskTabStateImpl) then) =
+      __$$TaskTabStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {List<List<PieChartSector>> sectors,
+      List<PieChartSector> allTodoSectors,
+      List<PieChartSector> exerciseTodoSectors,
+      List<PieChartSector> sleepTodoSectors,
+      List<PieChartSector> workTodoSectors,
+      int touchedSectionIndex});
+}
+
+/// @nodoc
+class __$$TaskTabStateImplCopyWithImpl<$Res>
+    extends _$TaskTabStateCopyWithImpl<$Res, _$TaskTabStateImpl>
+    implements _$$TaskTabStateImplCopyWith<$Res> {
+  __$$TaskTabStateImplCopyWithImpl(
+      _$TaskTabStateImpl _value, $Res Function(_$TaskTabStateImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? sectors = null,
+    Object? allTodoSectors = null,
+    Object? exerciseTodoSectors = null,
+    Object? sleepTodoSectors = null,
+    Object? workTodoSectors = null,
+    Object? touchedSectionIndex = null,
+  }) {
+    return _then(_$TaskTabStateImpl(
+      sectors: null == sectors
+          ? _value._sectors
+          : sectors // ignore: cast_nullable_to_non_nullable
+              as List<List<PieChartSector>>,
+      allTodoSectors: null == allTodoSectors
+          ? _value._allTodoSectors
+          : allTodoSectors // ignore: cast_nullable_to_non_nullable
+              as List<PieChartSector>,
+      exerciseTodoSectors: null == exerciseTodoSectors
+          ? _value._exerciseTodoSectors
+          : exerciseTodoSectors // ignore: cast_nullable_to_non_nullable
+              as List<PieChartSector>,
+      sleepTodoSectors: null == sleepTodoSectors
+          ? _value._sleepTodoSectors
+          : sleepTodoSectors // ignore: cast_nullable_to_non_nullable
+              as List<PieChartSector>,
+      workTodoSectors: null == workTodoSectors
+          ? _value._workTodoSectors
+          : workTodoSectors // ignore: cast_nullable_to_non_nullable
+              as List<PieChartSector>,
+      touchedSectionIndex: null == touchedSectionIndex
+          ? _value.touchedSectionIndex
+          : touchedSectionIndex // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$TaskTabStateImpl extends _TaskTabState {
+  _$TaskTabStateImpl(
+      {final List<List<PieChartSector>> sectors = const [],
+      final List<PieChartSector> allTodoSectors = const [],
+      final List<PieChartSector> exerciseTodoSectors = const [],
+      final List<PieChartSector> sleepTodoSectors = const [],
+      final List<PieChartSector> workTodoSectors = const [],
+      this.touchedSectionIndex = -1})
+      : _sectors = sectors,
+        _allTodoSectors = allTodoSectors,
+        _exerciseTodoSectors = exerciseTodoSectors,
+        _sleepTodoSectors = sleepTodoSectors,
+        _workTodoSectors = workTodoSectors,
+        super._();
+
+  final List<List<PieChartSector>> _sectors;
+  @override
+  @JsonKey()
+  List<List<PieChartSector>> get sectors {
+    if (_sectors is EqualUnmodifiableListView) return _sectors;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_sectors);
+  }
+
+  final List<PieChartSector> _allTodoSectors;
+  @override
+  @JsonKey()
+  List<PieChartSector> get allTodoSectors {
+    if (_allTodoSectors is EqualUnmodifiableListView) return _allTodoSectors;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_allTodoSectors);
+  }
+
+  final List<PieChartSector> _exerciseTodoSectors;
+  @override
+  @JsonKey()
+  List<PieChartSector> get exerciseTodoSectors {
+    if (_exerciseTodoSectors is EqualUnmodifiableListView)
+      return _exerciseTodoSectors;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_exerciseTodoSectors);
+  }
+
+  final List<PieChartSector> _sleepTodoSectors;
+  @override
+  @JsonKey()
+  List<PieChartSector> get sleepTodoSectors {
+    if (_sleepTodoSectors is EqualUnmodifiableListView)
+      return _sleepTodoSectors;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_sleepTodoSectors);
+  }
+
+  final List<PieChartSector> _workTodoSectors;
+  @override
+  @JsonKey()
+  List<PieChartSector> get workTodoSectors {
+    if (_workTodoSectors is EqualUnmodifiableListView) return _workTodoSectors;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_workTodoSectors);
+  }
+
+  @override
+  @JsonKey()
+  final int touchedSectionIndex;
+
+  @override
+  String toString() {
+    return 'TaskTabState(sectors: $sectors, allTodoSectors: $allTodoSectors, exerciseTodoSectors: $exerciseTodoSectors, sleepTodoSectors: $sleepTodoSectors, workTodoSectors: $workTodoSectors, touchedSectionIndex: $touchedSectionIndex)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$TaskTabStateImpl &&
+            const DeepCollectionEquality().equals(other._sectors, _sectors) &&
+            const DeepCollectionEquality()
+                .equals(other._allTodoSectors, _allTodoSectors) &&
+            const DeepCollectionEquality()
+                .equals(other._exerciseTodoSectors, _exerciseTodoSectors) &&
+            const DeepCollectionEquality()
+                .equals(other._sleepTodoSectors, _sleepTodoSectors) &&
+            const DeepCollectionEquality()
+                .equals(other._workTodoSectors, _workTodoSectors) &&
+            (identical(other.touchedSectionIndex, touchedSectionIndex) ||
+                other.touchedSectionIndex == touchedSectionIndex));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(_sectors),
+      const DeepCollectionEquality().hash(_allTodoSectors),
+      const DeepCollectionEquality().hash(_exerciseTodoSectors),
+      const DeepCollectionEquality().hash(_sleepTodoSectors),
+      const DeepCollectionEquality().hash(_workTodoSectors),
+      touchedSectionIndex);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$TaskTabStateImplCopyWith<_$TaskTabStateImpl> get copyWith =>
+      __$$TaskTabStateImplCopyWithImpl<_$TaskTabStateImpl>(this, _$identity);
+}
+
+abstract class _TaskTabState extends TaskTabState {
+  factory _TaskTabState(
+      {final List<List<PieChartSector>> sectors,
+      final List<PieChartSector> allTodoSectors,
+      final List<PieChartSector> exerciseTodoSectors,
+      final List<PieChartSector> sleepTodoSectors,
+      final List<PieChartSector> workTodoSectors,
+      final int touchedSectionIndex}) = _$TaskTabStateImpl;
+  _TaskTabState._() : super._();
+
+  @override
+  List<List<PieChartSector>> get sectors;
+  @override
+  List<PieChartSector> get allTodoSectors;
+  @override
+  List<PieChartSector> get exerciseTodoSectors;
+  @override
+  List<PieChartSector> get sleepTodoSectors;
+  @override
+  List<PieChartSector> get workTodoSectors;
+  @override
+  int get touchedSectionIndex;
+  @override
+  @JsonKey(ignore: true)
+  _$$TaskTabStateImplCopyWith<_$TaskTabStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/view/account_page/task_tab/task_tab.dart
+++ b/lib/view/account_page/task_tab/task_tab.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:serene_track/view/account_page/task_tab/components/grid_pie_charts.dart';
+
+class TaskTab extends StatelessWidget {
+  const TaskTab({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const SingleChildScrollView(
+      child: Column(
+        children: [
+          SizedBox(height: 16),
+          GridPieCharts(),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/view/todo_page/all_todo_tab/all_todo_tab.dart
+++ b/lib/view/todo_page/all_todo_tab/all_todo_tab.dart
@@ -9,6 +9,7 @@ import 'package:serene_track/constant/colors.dart';
 import 'package:serene_track/constant/text_source.dart';
 import 'package:serene_track/constant/themes/text_styles.dart';
 import 'package:serene_track/controllers/global/todo_notifier.dart';
+import 'package:serene_track/model/enum/category.dart';
 import 'package:serene_track/model/src/todo.dart';
 import 'package:serene_track/view/todo_page/all_todo_tab/provider/all_todo_tab_notifier.dart';
 import 'package:serene_track/view/todo_page/components/custom_checkbox_tile.dart';
@@ -41,16 +42,16 @@ class AllTodoTab extends ConsumerWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            const Icon(
+            Icon(
               LineIcons.alternateListAlt,
               size: 60,
-              color: sandwispColor2,
+              color: categoryColor2(Category.all),
             ),
             const SizedBox(height: 16),
             Text(
               'タスクを追加しましょう',
               style: TextStyles.taskTitleStyle.copyWith(
-                color: sandwispColor2,
+                color: categoryColor2(Category.all),
               ),
             ),
             const SizedBox(height: 260),
@@ -108,7 +109,7 @@ class AllTodoTab extends ConsumerWidget {
                   todos: allTodos,
                   index: index,
                   value: checkedList[index],
-                  fillColor: sandwispColor,
+                  fillColor: categoryColor(Category.all),
                   onTap: () {
                     ref
                         .read(allTodoTabProvider.notifier)

--- a/lib/view/todo_page/exercise_todo_tab/exercise_todo_tab.dart
+++ b/lib/view/todo_page/exercise_todo_tab/exercise_todo_tab.dart
@@ -8,6 +8,7 @@ import 'package:serene_track/constant/colors.dart';
 import 'package:serene_track/constant/text_source.dart';
 import 'package:serene_track/constant/themes/text_styles.dart';
 import 'package:serene_track/controllers/global/todo_notifier.dart';
+import 'package:serene_track/model/enum/category.dart';
 import 'package:serene_track/model/src/todo.dart';
 import 'package:serene_track/view/todo_page/exercise_todo_tab/provider/exercise_todo_tab_notifier.dart';
 import 'package:serene_track/view/todo_page/components/custom_checkbox_tile.dart';
@@ -17,12 +18,12 @@ class ExerciseTodoTab extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final exerciseTodos = ref.watch(
-        exerciseTodoTabProvider.select((value) => value.exerciseTodos));
+    final exerciseTodos = ref
+        .watch(exerciseTodoTabProvider.select((value) => value.exerciseTodos));
     final selectedItemList = ref
         .watch(exerciseTodoTabProvider.select((value) => value.isSelectedList));
-    final completeList =
-        ref.watch(exerciseTodoTabProvider.select((value) => value.completeList));
+    final completeList = ref
+        .watch(exerciseTodoTabProvider.select((value) => value.completeList));
     final isLoading =
         ref.watch(todoProvider.select((value) => value.isLoading));
 
@@ -31,16 +32,16 @@ class ExerciseTodoTab extends ConsumerWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            const Icon(
+            Icon(
               LineIcons.running,
               size: 60,
-              color: yellowGreenColor2,
+              color: categoryColor2(Category.exercise),
             ),
             const SizedBox(height: 16),
             Text(
               'タスクを追加しましょう',
               style: TextStyles.taskTitleStyle.copyWith(
-                color: yellowGreenColor2,
+                color: categoryColor2(Category.exercise),
               ),
             ),
             const SizedBox(height: 260),
@@ -97,7 +98,7 @@ class ExerciseTodoTab extends ConsumerWidget {
                   todos: exerciseTodos,
                   index: index,
                   value: completeList[index],
-                  fillColor: yellowGreenColor,
+                  fillColor: categoryColor(Category.exercise),
                   onTap: () {
                     ref
                         .read(exerciseTodoTabProvider.notifier)

--- a/lib/view/todo_page/sleep_todo_tab/sleep_todo_tab.dart
+++ b/lib/view/todo_page/sleep_todo_tab/sleep_todo_tab.dart
@@ -8,6 +8,7 @@ import 'package:serene_track/constant/colors.dart';
 import 'package:serene_track/constant/text_source.dart';
 import 'package:serene_track/constant/themes/text_styles.dart';
 import 'package:serene_track/controllers/global/todo_notifier.dart';
+import 'package:serene_track/model/enum/category.dart';
 import 'package:serene_track/model/src/todo.dart';
 import 'package:serene_track/view/todo_page/sleep_todo_tab/provider/sleep_todo_tab_notifier.dart';
 import 'package:serene_track/view/todo_page/components/custom_checkbox_tile.dart';
@@ -31,16 +32,16 @@ class SleepTodoTab extends ConsumerWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            const Icon(
+            Icon(
               LineIcons.procedures,
               size: 60,
-              color: mantisColor2,
+              color: categoryColor2(Category.sleep),
             ),
             const SizedBox(height: 16),
             Text(
               'タスクを追加しましょう',
               style: TextStyles.taskTitleStyle.copyWith(
-                color: mantisColor2,
+                color: categoryColor2(Category.sleep),
               ),
             ),
             const SizedBox(height: 260),
@@ -97,7 +98,7 @@ class SleepTodoTab extends ConsumerWidget {
                   todos: sleepTodos,
                   index: index,
                   value: completeList[index],
-                  fillColor: mantisColor,
+                  fillColor: categoryColor(Category.sleep),
                   onTap: () {
                     ref
                         .read(sleepTodoTabProvider.notifier)

--- a/lib/view/todo_page/todo_page.dart
+++ b/lib/view/todo_page/todo_page.dart
@@ -4,7 +4,9 @@ import 'package:go_router/go_router.dart';
 import 'package:line_icons/line_icons.dart';
 import 'package:serene_track/components/my_appbar.dart';
 import 'package:serene_track/constant/colors.dart';
+import 'package:serene_track/constant/text_source.dart';
 import 'package:serene_track/controllers/global/todo_notifier.dart';
+import 'package:serene_track/model/enum/category.dart';
 import 'package:serene_track/view/todo_add_page/todo_add_page.dart';
 import 'package:serene_track/view/todo_page/all_todo_tab/all_todo_tab.dart';
 import 'package:serene_track/view/todo_page/exercise_todo_tab/exercise_todo_tab.dart';
@@ -88,17 +90,17 @@ class TodoPageState extends ConsumerState<TodoPage>
                     fontSize: 13,
                     color: textMainColor,
                   ),
-                  colors: const [
-                    sandwispColor,
-                    yellowGreenColor,
-                    mantisColor,
-                    appleColor,
+                  colors: [
+                    categoryColor(Category.all),
+                    categoryColor(Category.exercise),
+                    categoryColor(Category.sleep),
+                    categoryColor(Category.work),
                   ],
                   tabs: const [
-                    Text('すべて'),
-                    Text('運動'),
-                    Text('睡眠'),
-                    Text('仕事'),
+                    Text(allTx),
+                    Text(exerciseTx),
+                    Text(sleepTx),
+                    Text(workTx),
                   ],
                   children: const [
                     AllTodoTab(),

--- a/lib/view/todo_page/work_todo_tab/work_todo_tab.dart
+++ b/lib/view/todo_page/work_todo_tab/work_todo_tab.dart
@@ -8,6 +8,7 @@ import 'package:serene_track/constant/colors.dart';
 import 'package:serene_track/constant/text_source.dart';
 import 'package:serene_track/constant/themes/text_styles.dart';
 import 'package:serene_track/controllers/global/todo_notifier.dart';
+import 'package:serene_track/model/enum/category.dart';
 import 'package:serene_track/model/src/todo.dart';
 import 'package:serene_track/view/todo_page/components/custom_checkbox_tile.dart';
 import 'package:serene_track/view/todo_page/work_todo_tab/provider/work_todo_tab_notifier.dart';
@@ -31,16 +32,13 @@ class WorkTodoTab extends ConsumerWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            const Icon(
-              LineIcons.briefcase,
-              size: 60,
-              color: appleColor2,
-            ),
+            Icon(LineIcons.briefcase,
+                size: 60, color: categoryColor2(Category.work)),
             const SizedBox(height: 16),
             Text(
               'タスクを追加しましょう',
               style: TextStyles.taskTitleStyle.copyWith(
-                color: appleColor2,
+                color: categoryColor2(Category.work),
               ),
             ),
             const SizedBox(height: 260),
@@ -97,7 +95,7 @@ class WorkTodoTab extends ConsumerWidget {
                   todos: workTodos,
                   index: index,
                   value: completeList[index],
-                  fillColor: appleColor,
+                  fillColor: categoryColor(Category.work),
                   onTap: () {
                     ref
                         .read(workTodoTabProvider.notifier)


### PR DESCRIPTION
### チケットへのリンク

- #34 

close #34

## ステータス

- タスクの完了

## やったこと

- タスクタブが持つステートの状態を管理するプロバイダーを作成

  - タスクの各カテゴリーでcompleteプロパティがtureになっているタスクの割合を取得

- グラフで各カテゴリーの達成率を表示する

  - fl_chartパッケージの円グラフでUI作成

  - gridviewやstackを使って表示方法を工夫

    - カテゴリーのタイトルを円グラフの真ん中に表示

    -  円グラフの各項目を円グラフの近くにわかりやすく表示させた

  - タップ時にタップ部分が少し拡大する仕様を追加


## 改善点

- 表示する際にsingleScrollViewを使用したが、customScrollViewを使用した方が良いのでは？