### PR TITLE
スプラッシュ画面でヘルスケアアプリ情報を取得できるようにする(連携済みのユーザーのみ) 

### DIFF
--- a/lib/controllers/global/health_care_notifier.dart
+++ b/lib/controllers/global/health_care_notifier.dart
@@ -1,0 +1,135 @@
+import 'dart:async';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:health/health.dart';
+import 'package:serene_track/controllers/global/user_notifier.dart';
+import 'package:serene_track/view/account_page/sleep_tab/provider/sleep_tab_notifier.dart';
+import 'package:serene_track/view/account_page/steps_tab/provider/steps_tab_notifier.dart';
+
+part 'health_care_notifier.freezed.dart';
+
+@freezed
+class HealthCareState with _$HealthCareState {
+  const factory HealthCareState({
+    Health? health,
+  }) = _HealthCareState;
+}
+
+final healthCareProvider =
+    StateNotifierProvider<HealthCareController, HealthCareState>(
+  (ref) {
+    final userNotifier = ref.watch(userProvider.notifier);
+    return HealthCareController(ref: ref, userNotifier: userNotifier);
+  },
+  dependencies: [userProvider],
+);
+
+class HealthCareController extends StateNotifier<HealthCareState> {
+  HealthCareController({
+    required ref,
+    required userNotifier,
+  })  : _ref = ref,
+        _userNotifier = userNotifier,
+        super(const HealthCareState()) {
+    init();
+  }
+
+  final StateNotifierProviderRef<HealthCareController, HealthCareState> _ref;
+  final UserController _userNotifier;
+
+  Future<void> init() async {
+    Health health = Health();
+    state = state.copyWith(health: health);
+    if (state.health != null) checkHealthDataAccess(state.health!);
+  }
+
+  static final types = [
+    HealthDataType.STEPS,
+    HealthDataType.SLEEP_IN_BED,
+    HealthDataType.SLEEP_ASLEEP,
+    HealthDataType.SLEEP_AWAKE,
+    HealthDataType.SLEEP_DEEP,
+    HealthDataType.SLEEP_REM,
+  ];
+
+  Future<void> checkHealthDataAccess(Health health) async {
+    try {
+      List<HealthDataPoint> healthData = await health.getHealthDataFromTypes(
+        startTime: DateTime.now().subtract(const Duration(days: 6)),
+        endTime: DateTime.now(),
+        types: types,
+      );
+      bool hasPermissions = healthData.isNotEmpty;
+      await _userNotifier.updateHealthDataIntegrationStatus(hasPermissions);
+      if (hasPermissions) {
+        fetchData(health);
+      }
+    } catch (e) {
+      await _userNotifier.updateHealthDataIntegrationStatus(false);
+      throw ('Error: $e');
+    }
+  }
+
+  Future<void> fetchData(Health health) async {
+    try {
+      DateTime startOfDay = DateTime.now().subtract(const Duration(days: 6));
+      DateTime endOfDay = DateTime.now();
+
+      List<HealthDataPoint> healthDataPoints =
+          await health.getHealthDataFromTypes(
+        startTime: startOfDay,
+        endTime: endOfDay,
+        types: types,
+      );
+
+      if (healthDataPoints.isEmpty) {
+        return;
+      }
+
+      healthDataPoints = health.removeDuplicates(healthDataPoints);
+
+      Map<DateTime, int> dailyStepsMap = {};
+      Map<DateTime, int> dailySleepHoursMap = {};
+
+      for (var dataPoint in healthDataPoints) {
+        dynamic year = dataPoint.dateFrom.year;
+        int month = dataPoint.dateFrom.month;
+        int day = dataPoint.dateFrom.day;
+        DateTime date = DateTime(year, month, day);
+
+        num stepValue = 0;
+        num sleepHoursValue = 0;
+        if (dataPoint.type == HealthDataType.STEPS &&
+            dataPoint.value is NumericHealthValue) {
+          stepValue = (dataPoint.value as NumericHealthValue).numericValue;
+        } else if (dataPoint.type == HealthDataType.SLEEP_IN_BED) {
+          sleepHoursValue =
+              (dataPoint.value as NumericHealthValue).numericValue;
+        }
+
+        if (!dailyStepsMap.containsKey(date)) {
+          dailyStepsMap[date] = 0;
+          dailySleepHoursMap[date] = 0;
+        }
+
+        dailyStepsMap[date] = dailyStepsMap[date]! + stepValue.toInt();
+        dailySleepHoursMap[date] =
+            dailySleepHoursMap[date]! + sleepHoursValue.toInt();
+      }
+
+      List<int> steps = [];
+      List<int> sleepHours = [];
+      for (int i = 0; i < 7; i++) {
+        DateTime day =
+            DateTime(startOfDay.year, startOfDay.month, startOfDay.day)
+                .add(Duration(days: i));
+        steps.add(dailyStepsMap[day] ?? 0);
+        sleepHours.add(dailySleepHoursMap[day] ?? 0);
+      }
+      _ref.read(stepsTabProvider.notifier).getSteps(steps);
+      _ref.read(sleepTabProvider.notifier).getWeekSleepHours(sleepHours);
+    } catch (e) {
+      throw ('Error: $e');
+    }
+  }
+}

--- a/lib/controllers/global/health_care_notifier.freezed.dart
+++ b/lib/controllers/global/health_care_notifier.freezed.dart
@@ -1,0 +1,134 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'health_care_notifier.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$HealthCareState {
+  Health? get health => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $HealthCareStateCopyWith<HealthCareState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $HealthCareStateCopyWith<$Res> {
+  factory $HealthCareStateCopyWith(
+          HealthCareState value, $Res Function(HealthCareState) then) =
+      _$HealthCareStateCopyWithImpl<$Res, HealthCareState>;
+  @useResult
+  $Res call({Health? health});
+}
+
+/// @nodoc
+class _$HealthCareStateCopyWithImpl<$Res, $Val extends HealthCareState>
+    implements $HealthCareStateCopyWith<$Res> {
+  _$HealthCareStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? health = freezed,
+  }) {
+    return _then(_value.copyWith(
+      health: freezed == health
+          ? _value.health
+          : health // ignore: cast_nullable_to_non_nullable
+              as Health?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$HealthCareStateImplCopyWith<$Res>
+    implements $HealthCareStateCopyWith<$Res> {
+  factory _$$HealthCareStateImplCopyWith(_$HealthCareStateImpl value,
+          $Res Function(_$HealthCareStateImpl) then) =
+      __$$HealthCareStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({Health? health});
+}
+
+/// @nodoc
+class __$$HealthCareStateImplCopyWithImpl<$Res>
+    extends _$HealthCareStateCopyWithImpl<$Res, _$HealthCareStateImpl>
+    implements _$$HealthCareStateImplCopyWith<$Res> {
+  __$$HealthCareStateImplCopyWithImpl(
+      _$HealthCareStateImpl _value, $Res Function(_$HealthCareStateImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? health = freezed,
+  }) {
+    return _then(_$HealthCareStateImpl(
+      health: freezed == health
+          ? _value.health
+          : health // ignore: cast_nullable_to_non_nullable
+              as Health?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$HealthCareStateImpl implements _HealthCareState {
+  const _$HealthCareStateImpl({this.health});
+
+  @override
+  final Health? health;
+
+  @override
+  String toString() {
+    return 'HealthCareState(health: $health)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$HealthCareStateImpl &&
+            (identical(other.health, health) || other.health == health));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, health);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$HealthCareStateImplCopyWith<_$HealthCareStateImpl> get copyWith =>
+      __$$HealthCareStateImplCopyWithImpl<_$HealthCareStateImpl>(
+          this, _$identity);
+}
+
+abstract class _HealthCareState implements HealthCareState {
+  const factory _HealthCareState({final Health? health}) =
+      _$HealthCareStateImpl;
+
+  @override
+  Health? get health;
+  @override
+  @JsonKey(ignore: true)
+  _$$HealthCareStateImplCopyWith<_$HealthCareStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/view/account_page/sleep_tab/components/week_average_sleep_hours_card.dart
+++ b/lib/view/account_page/sleep_tab/components/week_average_sleep_hours_card.dart
@@ -27,11 +27,11 @@ class WeekAverageSleepHoursCard extends ConsumerWidget {
                     color: healthCareSleepColor,
                   ),
                   Text(
-                    '今週の睡眠時間',
+                    '今週の平均睡眠時間',
                     style: TextStyle(
                       color: healthCareSleepColor,
                       fontWeight: FontWeight.bold,
-                    ),
+                    ), 
                   ),
                 ],
               ),

--- a/lib/view/auth_page/sign_in_page/sign_in_page.dart
+++ b/lib/view/auth_page/sign_in_page/sign_in_page.dart
@@ -14,7 +14,7 @@ import 'package:serene_track/view/auth_page/provider/form_provider.dart';
 import 'package:serene_track/view/auth_page/sign_in_page/provider/form_key_for_sign_in_notifier.dart';
 import 'package:serene_track/view/auth_page/sign_in_page/provider/sign_in_text_controller_notifier.dart';
 import 'package:serene_track/view/auth_page/sign_up_page/sign_up_page.dart';
-import 'package:serene_track/view/todo_page/todo_page.dart';
+import 'package:serene_track/view/splash_page/splash_page.dart';
 
 class SignInPage extends ConsumerWidget {
   const SignInPage({super.key});
@@ -150,7 +150,7 @@ class SignInPage extends ConsumerWidget {
                         );
                         if (res == successSignIn) {
                           if (!context.mounted) return;
-                          context.go(TodoPage.routeLocation);
+                          context.go(SplashPage.routeLocation);
                         }
                         if (!context.mounted) return;
                         showSnackBar(res, context);

--- a/lib/view/auth_page/sign_up_page/sign_up_page.dart
+++ b/lib/view/auth_page/sign_up_page/sign_up_page.dart
@@ -14,7 +14,7 @@ import 'package:serene_track/view/auth_page/provider/form_provider.dart';
 import 'package:serene_track/view/auth_page/sign_in_page/sign_in_page.dart';
 import 'package:serene_track/view/auth_page/sign_up_page/provider/sign_up_text_cotroller_notifier.dart';
 import 'package:serene_track/view/auth_page/sign_up_page/provider/form_key_for_sign_up_notifier.dart';
-import 'package:serene_track/view/todo_page/todo_page.dart';
+import 'package:serene_track/view/splash_page/splash_page.dart';
 
 class SignUpPage extends ConsumerWidget {
   const SignUpPage({super.key});
@@ -162,7 +162,7 @@ class SignUpPage extends ConsumerWidget {
                           );
                           if (res == successSignUp) {
                             if (!context.mounted) return;
-                            context.go(TodoPage.routeLocation);
+                            context.go(SplashPage.routeLocation);
                           }
                           if (!context.mounted) return;
                           showSnackBar(res, context);

--- a/lib/view/health_care_page/health_care_app_integration_page.dart
+++ b/lib/view/health_care_page/health_care_app_integration_page.dart
@@ -3,148 +3,23 @@ import 'dart:io';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:health/health.dart';
 import 'package:serene_track/components/my_appbar.dart';
 import 'package:serene_track/components/show_snack_bar.dart';
 import 'package:serene_track/constant/colors.dart';
 import 'package:serene_track/constant/themes/text_styles.dart';
+import 'package:serene_track/controllers/global/health_care_notifier.dart';
 import 'package:serene_track/controllers/global/user_notifier.dart';
-import 'package:serene_track/view/account_page/sleep_tab/provider/sleep_tab_notifier.dart';
-import 'package:serene_track/view/account_page/steps_tab/provider/steps_tab_notifier.dart';
 import 'package:serene_track/view/health_care_page/components/cancellation_of_integration_with_health_care_app_dialog.dart';
 import 'package:serene_track/view/health_care_page/components/show_allow_access_to_health_care_app_dialog.dart';
 
-class HealthCareAppIntegrationPage extends ConsumerStatefulWidget {
+class HealthCareAppIntegrationPage extends StatelessWidget {
   const HealthCareAppIntegrationPage({super.key});
   static String get routeName => 'health_care_app_integration';
   static String get routeLocation => '/$routeName';
 
-  @override
-  // ignore: library_private_types_in_public_api
-  _HealthCareAppIntegrationPageState createState() =>
-      _HealthCareAppIntegrationPageState();
-}
-
-class _HealthCareAppIntegrationPageState
-    extends ConsumerState<HealthCareAppIntegrationPage>
-    with WidgetsBindingObserver {
-  Health health = Health();
-
-  @override
-  void initState() {
-    super.initState();
-    WidgetsBinding.instance.addObserver(this);
-    checkHealthDataAccess();
-  }
-
-  @override
-  void didChangeAppLifecycleState(AppLifecycleState state) {
-    if (state == AppLifecycleState.resumed) {
-      checkHealthDataAccess();
-    }
-  }
-
-  @override
-  void dispose() {
-    WidgetsBinding.instance.removeObserver(this);
-    super.dispose();
-  }
-
-  static final types = [
-    HealthDataType.STEPS,
-    HealthDataType.SLEEP_IN_BED,
-    HealthDataType.SLEEP_ASLEEP,
-    HealthDataType.SLEEP_AWAKE,
-    HealthDataType.SLEEP_DEEP,
-    HealthDataType.SLEEP_REM,
-  ];
-
-  Future<void> fetchData() async {
-    try {
-      DateTime startOfDay = DateTime.now().subtract(const Duration(days: 6));
-      DateTime endOfDay = DateTime.now();
-
-      List<HealthDataPoint> healthDataPoints =
-          await health.getHealthDataFromTypes(
-        startTime: startOfDay,
-        endTime: endOfDay,
-        types: types,
-      );
-
-      if (healthDataPoints.isEmpty) {
-        return;
-      }
-
-      healthDataPoints = health.removeDuplicates(healthDataPoints);
-
-      Map<DateTime, int> dailyStepsMap = {};
-      Map<DateTime, int> dailySleepHoursMap = {};
-
-      for (var dataPoint in healthDataPoints) {
-        dynamic year = dataPoint.dateFrom.year;
-        int month = dataPoint.dateFrom.month;
-        int day = dataPoint.dateFrom.day;
-        DateTime date = DateTime(year, month, day);
-
-        num stepValue = 0;
-        num sleepHoursValue = 0;
-        if (dataPoint.type == HealthDataType.STEPS &&
-            dataPoint.value is NumericHealthValue) {
-          stepValue = (dataPoint.value as NumericHealthValue).numericValue;
-        } else if (dataPoint.type == HealthDataType.SLEEP_IN_BED) {
-          sleepHoursValue =
-              (dataPoint.value as NumericHealthValue).numericValue;
-        }
-
-        if (!dailyStepsMap.containsKey(date)) {
-          dailyStepsMap[date] = 0;
-          dailySleepHoursMap[date] = 0;
-        }
-
-        dailyStepsMap[date] = dailyStepsMap[date]! + stepValue.toInt();
-        dailySleepHoursMap[date] =
-            dailySleepHoursMap[date]! + sleepHoursValue.toInt();
-      }
-
-      List<int> steps = [];
-      List<int> sleepHours = [];
-      for (int i = 0; i < 7; i++) {
-        DateTime day =
-            DateTime(startOfDay.year, startOfDay.month, startOfDay.day)
-                .add(Duration(days: i));
-        steps.add(dailyStepsMap[day] ?? 0);
-        sleepHours.add(dailySleepHoursMap[day] ?? 0);
-      }
-      ref.read(stepsTabProvider.notifier).getSteps(steps);
-      ref.read(sleepTabProvider.notifier).getWeekSleepHours(sleepHours);
-    } catch (e) {
-      throw ('Error: $e');
-    }
-  }
-
-  Future<void> checkHealthDataAccess() async {
-    try {
-      List<HealthDataPoint> healthData = await health.getHealthDataFromTypes(
-        startTime: DateTime.now().subtract(const Duration(days: 1)),
-        endTime: DateTime.now(),
-        types: types,
-      );
-
-      bool hasPermissions = healthData.isNotEmpty;
-      ref
-          .read(userProvider.notifier)
-          .updateHealthDataIntegrationStatus(hasPermissions);
-      if (hasPermissions) {
-        fetchData();
-      }
-    } catch (e) {
-      ref.read(userProvider.notifier).updateHealthDataIntegrationStatus(false);
-      throw ('Error: $e');
-    }
-  }
-
   Future<void> requestPermissions({
     required BuildContext context,
+    required WidgetRef ref,
     required bool isRequested,
   }) async {
     if (isRequested) {
@@ -165,7 +40,9 @@ class _HealthCareAppIntegrationPageState
         showCancellationOfIntegrationHealthCareAppDialog(context);
       } else {
         try {
-          await health.revokePermissions();
+          final health =
+              ref.watch(healthCareProvider.select((value) => value.health));
+          if (health != null) await health.revokePermissions();
           ref
               .read(userProvider.notifier)
               .updateHealthDataIntegrationStatus(false);
@@ -179,8 +56,6 @@ class _HealthCareAppIntegrationPageState
 
   @override
   Widget build(BuildContext context) {
-    final healthDataIntegrationStatus = ref.watch(
-        userProvider.select((value) => value.user.healthDataIntegrationStatus));
     return Scaffold(
       backgroundColor: backGroundColor,
       appBar: myAppBar(
@@ -197,20 +72,29 @@ class _HealthCareAppIntegrationPageState
                 'ヘルスケアアプリと連携',
                 style: TextStyles.caption,
               ),
-              trailing: CupertinoSwitch(
-                value: healthDataIntegrationStatus,
-                onChanged: (value) async {
-                  if (value) {
-                    await requestPermissions(
-                      context: context,
-                      isRequested: true,
-                    );
-                  } else {
-                    await requestPermissions(
-                      context: context,
-                      isRequested: false,
-                    );
-                  }
+              trailing: Consumer(
+                builder: (context, ref, _) {
+                  final healthDataIntegrationStatus = ref.watch(
+                      userProvider.select(
+                          (value) => value.user.healthDataIntegrationStatus));
+                  return CupertinoSwitch(
+                    value: healthDataIntegrationStatus,
+                    onChanged: (value) async {
+                      if (value) {
+                        await requestPermissions(
+                          context: context,
+                          ref: ref,
+                          isRequested: true,
+                        );
+                      } else {
+                        await requestPermissions(
+                          context: context,
+                          ref: ref,
+                          isRequested: false,
+                        );
+                      }
+                    },
+                  );
                 },
               ),
             ),

--- a/lib/view/splash_page/splash_page.dart
+++ b/lib/view/splash_page/splash_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:serene_track/constant/colors.dart';
+import 'package:serene_track/controllers/global/health_care_notifier.dart';
 import 'package:serene_track/view/auth_page/sign_in_page/sign_in_page.dart';
 import 'package:serene_track/view/splash_page/splash_page_notifier.dart';
 import 'package:serene_track/view/todo_page/todo_page.dart';
@@ -18,6 +19,9 @@ class SplashPage extends ConsumerWidget {
         ref.listen<bool?>(splashPageProvider.select((value) => value.isLogin),
             (_, isLogin) async {
           if (isLogin == true) {
+            ref.watch(healthCareProvider);
+            await Future.delayed(const Duration(seconds: 2));
+            if (!context.mounted) return;
             context.go(TodoPage.routeLocation);
           } else {
             context.go(SignInPage.routeLocation);
@@ -34,12 +38,4 @@ class SplashPage extends ConsumerWidget {
       },
     );
   }
-
-  // Widget buildGlobalProvider() {
-  //   return Consumer(
-  //     builder: (context, ref, _) {
-  //       return const SizedBox.shrink();
-  //     },
-  //   );
-  // }
 }

--- a/lib/view/todo_add_page/todo_add_page.dart
+++ b/lib/view/todo_add_page/todo_add_page.dart
@@ -97,28 +97,30 @@ class TodoAddPage extends ConsumerWidget {
                 SizedBox(
                   height: 56,
                   width: 72,
-                  child: Consumer(builder: (context, ref, _) {
-                    return DropdownButton(
-                      dropdownColor: backGroundColor,
-                      items: items
-                          .map((item) => DropdownMenuItem<Category>(
-                                alignment: AlignmentDirectional.center,
-                                value: item,
-                                child: Text(item.label),
-                              ))
-                          .toList(),
-                      value: ref.watch(categoryNotifierProvider),
-                      onChanged: (value) {
-                        ref
-                            .read(categoryNotifierProvider.notifier)
-                            .setValue(value);
-                      },
-                      underline: Container(
-                        height: 1,
-                        color: textMainColor,
-                      ),
-                    );
-                  }),
+                  child: Consumer(
+                    builder: (context, ref, _) {
+                      return DropdownButton(
+                        dropdownColor: backGroundColor,
+                        items: items
+                            .map((item) => DropdownMenuItem<Category>(
+                                  alignment: AlignmentDirectional.center,
+                                  value: item,
+                                  child: Text(item.label),
+                                ))
+                            .toList(),
+                        value: ref.watch(categoryNotifierProvider),
+                        onChanged: (value) {
+                          ref
+                              .read(categoryNotifierProvider.notifier)
+                              .setValue(value);
+                        },
+                        underline: Container(
+                          height: 1,
+                          color: textMainColor,
+                        ),
+                      );
+                    },
+                  ),
                 ),
                 const SizedBox(height: 8),
                 TodoTextField(


### PR DESCRIPTION
### チケットへのリンク

- #36 

close #36

## ステータス

- タスクの完了

## やったこと

- ヘルスデータを取得するプロバイダーを作成し、グローバルに使用できるようにした

- スプラッシュ画面でヘルスデータを取得できるようにした(連携済みのユーザーのみ) 

- サインイン・サインアップ時もスプラッシュ画面に遷移するように修正した

## 改善点

- ヘルスデータを取得する際に、TodoControllerのdisoposeを防ぐために、スプラッシュ画面でFuture.delayed関数を使用して画面遷移処理を遅らる工夫をしたが、解決方法はこれで適切かどうか考える