### PR TITLE
利用規約、プライバシーポリシーの作成と初回起動時の処理を実装

### DIFF
--- a/lib/constant/constants.dart
+++ b/lib/constant/constants.dart
@@ -1,2 +1,6 @@
 const kBaseUrl = 'http://localhost:8000';
 const kHealthCareAppUrl = 'x-apple-health://';
+
+const kAppTermsUrl = 'https://kiichi7580.github.io/serene_track_tos/';
+const kAppPrivacyPolicyUrl =
+    'https://kiichi7580.github.io/serene_track_privacy_policy/';

--- a/lib/infrastructure/todo/todo_repository_impl.dart
+++ b/lib/infrastructure/todo/todo_repository_impl.dart
@@ -1,5 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:serene_track/constant/text_source.dart';
 import 'package:serene_track/controllers/global/dio_notifier.dart';
 import 'package:serene_track/model/src/result.dart';
 import 'package:serene_track/model/src/todo.dart';
@@ -167,6 +168,28 @@ class TodoRepositoryImpl implements TodoRepository {
         return todo;
       } else {
         throw Exception('Unexpected response format');
+      }
+    });
+  }
+
+  @override
+  Future<Result<String>> deleteTodos({
+    required String accessToken,
+    required String tokenType,
+  }) {
+    return Result.guardFuture(() async {
+      await Future.delayed(const Duration(seconds: 1));
+
+      final response = await _dio.delete(
+        '/todos/',
+        options: Options(
+          headers: {'Authorization': '$tokenType $accessToken'},
+        ),
+      );
+      if (response.statusCode == 204) {
+        return successDelete;
+      } else {
+        return Exception('Unexpected response format').toString();
       }
     });
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,7 +28,9 @@ class MyApp extends ConsumerWidget {
       routerDelegate: router.routerDelegate,
       routeInformationProvider: router.routeInformationProvider,
       debugShowCheckedModeBanner: false,
-      supportedLocales: const [Locale('ja', 'JP')],
+      supportedLocales: const [
+        Locale('ja', 'JP'),
+      ],
       localizationsDelegates: const [
         GlobalMaterialLocalizations.delegate,
         GlobalWidgetsLocalizations.delegate,

--- a/lib/repository/todo/todo_repository.dart
+++ b/lib/repository/todo/todo_repository.dart
@@ -40,4 +40,9 @@ abstract class TodoRepository {
     required FormData formData,
     required Todo todo,
   });
+
+  Future<Result<String>> deleteTodos({
+    required String accessToken,
+    required String tokenType,
+  });
 }

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -14,6 +14,7 @@ import 'package:serene_track/view/health_care_page/health_care_app_integration_p
 import 'package:serene_track/view/montring_page/montring_page.dart';
 import 'package:serene_track/view/notification_setting_page/notification_setting_page.dart';
 import 'package:serene_track/view/splash_page/splash_page.dart';
+import 'package:serene_track/view/start_stepper_page/start_stepper_page.dart';
 import 'package:serene_track/view/todo_add_page/todo_add_page.dart';
 import 'package:serene_track/view/todo_edit_page/todo_edit_page.dart';
 import 'package:serene_track/view/todo_notification_page/todo_notification_page.dart';
@@ -34,6 +35,13 @@ final routerProvider = Provider<GoRouter>(
           name: SplashPage.routeName,
           builder: (context, state) {
             return const SplashPage();
+          },
+        ),
+        GoRoute(
+          path: StartStepperPage.routeLocation,
+          name: StartStepperPage.routeName,
+          builder: (context, state) {
+            return const StartStepperPage();
           },
         ),
         GoRoute(

--- a/lib/utils/notification/todo_notifications.dart
+++ b/lib/utils/notification/todo_notifications.dart
@@ -8,7 +8,7 @@ final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
     FlutterLocalNotificationsPlugin();
 
 // タスク通知 複数設定可
-Future<void> dailyProteinNotifications(List<Todo> todos) async {
+Future<void> dailyTodoNotifications(List<Todo> todos) async {
   for (int i = 0; i < todos.length; i++) {
     await dailyTodoNotification(todos[i]);
   }

--- a/lib/utils/preferences_manager.dart
+++ b/lib/utils/preferences_manager.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:serene_track/model/src/todo.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+const String _isFirstLaunchAfterInstallKey = '_isFirstLaunchAfterInstall';
 const String _isLoginKey = 'isLogin';
 const String _accessTokenKey = 'accessToken';
 const String _tokenTypeKey = 'tokenType';
@@ -19,6 +20,17 @@ class PreferencesManager {
 
   Future<void> set(SharedPreferences preferences) async =>
       _preferences = preferences;
+
+  Future<bool> get isFirstLaunchAfterInstall async {
+    return _preferences.getBool(_isFirstLaunchAfterInstallKey) ?? true;
+  }
+
+  Future<void> setIsFirstLaunchAfterInstall({
+    required bool isFirstLaunchAfterInstall,
+  }) async {
+    await _preferences.setBool(
+        _isFirstLaunchAfterInstallKey, isFirstLaunchAfterInstall);
+  }
 
   Future<bool> get isLogin async {
     return _preferences.getBool(_isLoginKey) ?? false;

--- a/lib/view/account_setting_page/account_setting_page.dart
+++ b/lib/view/account_setting_page/account_setting_page.dart
@@ -6,14 +6,17 @@ import 'package:serene_track/components/dialog/show_delete_confirmation_dialog.d
 import 'package:serene_track/components/my_appbar.dart';
 import 'package:serene_track/components/show_snack_bar.dart';
 import 'package:serene_track/constant/colors.dart';
+import 'package:serene_track/constant/constants.dart';
 import 'package:serene_track/constant/text_source.dart';
 import 'package:serene_track/constant/themes/text_styles.dart';
+import 'package:serene_track/controllers/global/todo_notifier.dart';
 import 'package:serene_track/controllers/global/user_notifier.dart';
 import 'package:serene_track/view/account_setting_page/components/show_sign_out_dialog.dart';
 import 'package:serene_track/view/auth_page/sign_in_page/sign_in_page.dart';
 import 'package:serene_track/view/health_care_page/health_care_app_integration_page.dart';
 import 'package:serene_track/view/notification_setting_page/notification_setting_page.dart';
 import 'package:serene_track/view/todo_notification_page/todo_notification_page.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class AccountSettingPage extends ConsumerWidget {
   const AccountSettingPage({super.key});
@@ -53,8 +56,34 @@ class AccountSettingPage extends ConsumerWidget {
             },
           ),
           settingItem2(
+            title: '利用規約',
+            iconData: LineIcons.fileInvoice,
+            onTap: () async {
+              final url = Uri.parse(kAppTermsUrl);
+              if (await canLaunchUrl(url)) {
+                await launchUrl(url);
+              } else {
+                throw '利用規約のリンクが開けません: $url';
+              }
+            },
+          ),
+          settingItem2(
+            title: 'プライバシーポリシー',
+            iconData: LineIcons.userShield,
+            onTap: () async {
+              final url = Uri.parse(kAppPrivacyPolicyUrl);
+              if (await canLaunchUrl(url)) {
+                await launchUrl(url);
+              } else {
+                throw 'プライバシーポリシーのリンクが開けません: $url';
+              }
+            },
+          ),
+          settingItem2(
             title: 'サインアウトする',
             iconData: LineIcons.alternateSignOut,
+            iconColor: noReactionColor,
+            textColor: noReactionColor,
             onTap: () async {
               final response = await showSignOutDialog(context);
               if (response == null || response == false) {
@@ -68,15 +97,21 @@ class AccountSettingPage extends ConsumerWidget {
           settingItem2(
             title: 'アカウントを削除する',
             iconData: LineIcons.userSlash,
+            iconColor: noReactionColor,
+            textColor: noReactionColor,
             onTap: () async {
               final response = await showDeleteConfirmationDialog(context);
               if (response == null || response == false) {
                 return;
               }
-              String res = await ref.read(userProvider.notifier).deleteUser();
+              String res = await ref.read(todoProvider.notifier).deleteTodos();
               if (res == successRes) {
-                if (!context.mounted) return;
-                context.go(SignInPage.routeLocation);
+                String res = await ref.read(userProvider.notifier).deleteUser();
+                if (res == successRes) {
+                  await ref.read(userProvider.notifier).signOut();
+                  if (!context.mounted) return;
+                  context.go(SignInPage.routeLocation);
+                }
               } else {
                 if (!context.mounted) return;
                 showSnackBar(
@@ -110,13 +145,15 @@ class AccountSettingPage extends ConsumerWidget {
     required String title,
     required IconData? iconData,
     required void Function()? onTap,
+    Color? iconColor,
+    Color? textColor,
   }) {
     return ListTile(
       contentPadding: const EdgeInsets.symmetric(horizontal: 16.0),
-      leading: Icon(iconData, color: noReactionColor),
+      leading: Icon(iconData, color: iconColor),
       title: Text(
         title,
-        style: TextStyles.caption.copyWith(color: noReactionColor),
+        style: TextStyles.caption.copyWith(color: textColor),
       ),
       onTap: onTap,
     );

--- a/lib/view/auth_page/sign_in_page/sign_in_page.dart
+++ b/lib/view/auth_page/sign_in_page/sign_in_page.dart
@@ -223,9 +223,6 @@ class SignInPage extends ConsumerWidget {
                 ),
               ],
             ),
-            SizedBox(
-              height: MediaQuery.of(context).size.height * 0.1,
-            ),
           ],
         ),
       ),

--- a/lib/view/auth_page/sign_up_page/sign_up_page.dart
+++ b/lib/view/auth_page/sign_up_page/sign_up_page.dart
@@ -241,9 +241,6 @@ class SignUpPage extends ConsumerWidget {
                   ),
                 ],
               ),
-              SizedBox(
-                height: MediaQuery.of(context).size.height * 0.1,
-              ),
             ],
           ),
         ),

--- a/lib/view/auth_page/sign_up_page/sign_up_page.dart
+++ b/lib/view/auth_page/sign_up_page/sign_up_page.dart
@@ -15,6 +15,7 @@ import 'package:serene_track/view/auth_page/sign_in_page/sign_in_page.dart';
 import 'package:serene_track/view/auth_page/sign_up_page/provider/sign_up_text_cotroller_notifier.dart';
 import 'package:serene_track/view/auth_page/sign_up_page/provider/form_key_for_sign_up_notifier.dart';
 import 'package:serene_track/view/splash_page/splash_page.dart';
+import 'package:serene_track/view/splash_page/splash_page_notifier.dart';
 
 class SignUpPage extends ConsumerWidget {
   const SignUpPage({super.key});
@@ -34,6 +35,11 @@ class SignUpPage extends ConsumerWidget {
     if (signUpRes == successRes && getUserRes == successRes) {
       res = successSignUp;
       await PreferencesManager().setIsLogin(isLogin: true);
+      await PreferencesManager()
+          .setIsFirstLaunchAfterInstall(isFirstLaunchAfterInstall: true);
+      ref
+          .read(splashPageProvider.notifier)
+          .changeIsFirstLaunchAfterInstall(true);
     }
     return res;
   }

--- a/lib/view/health_care_page/components/cancellation_of_integration_with_health_care_app_dialog.dart
+++ b/lib/view/health_care_page/components/cancellation_of_integration_with_health_care_app_dialog.dart
@@ -59,7 +59,7 @@ Widget _buildCancellationOfIntegrationHealthCareAppDialog(
                 if (await canLaunchUrl(url)) {
                   await launchUrl(url);
                 } else {
-                  throw 'Could not launch $url';
+                  throw 'ヘルスケアアプリのリンクが開けません: $url';
                 }
               }
             },

--- a/lib/view/splash_page/splash_page.dart
+++ b/lib/view/splash_page/splash_page.dart
@@ -5,6 +5,7 @@ import 'package:serene_track/constant/colors.dart';
 import 'package:serene_track/controllers/global/health_care_notifier.dart';
 import 'package:serene_track/view/auth_page/sign_in_page/sign_in_page.dart';
 import 'package:serene_track/view/splash_page/splash_page_notifier.dart';
+import 'package:serene_track/view/start_stepper_page/start_stepper_page.dart';
 import 'package:serene_track/view/todo_page/todo_page.dart';
 
 class SplashPage extends ConsumerWidget {
@@ -18,7 +19,13 @@ class SplashPage extends ConsumerWidget {
       builder: (context, ref, _) {
         ref.listen<bool?>(splashPageProvider.select((value) => value.isLogin),
             (_, isLogin) async {
-          if (isLogin == true) {
+          final isFirstLaunchAfterInstall = ref.watch(splashPageProvider
+              .select((value) => value.isFirstLaunchAfterInstall));
+          if (isLogin == true && isFirstLaunchAfterInstall == true) {
+            await Future.delayed(const Duration(seconds: 2));
+            if (!context.mounted) return;
+            context.go(StartStepperPage.routeLocation);
+          } else if (isLogin == true) {
             ref.watch(healthCareProvider);
             await Future.delayed(const Duration(seconds: 2));
             if (!context.mounted) return;

--- a/lib/view/splash_page/splash_page_notifier.dart
+++ b/lib/view/splash_page/splash_page_notifier.dart
@@ -10,6 +10,7 @@ part 'splash_page_notifier.freezed.dart';
 class SplashPageState with _$SplashPageState {
   const factory SplashPageState({
     bool? isLogin,
+    bool? isFirstLaunchAfterInstall,
   }) = _SplashPageState;
 }
 
@@ -35,11 +36,24 @@ class SplashPageController extends StateNotifier<SplashPageState> {
     await Future.delayed(const Duration(seconds: 1));
     if (_isAuthenticated && mounted) {
       final isLogin = await PreferencesManager().isLogin;
-      state = state.copyWith(isLogin: isLogin);
+      final isFirstLaunchAfterInstall =
+          await PreferencesManager().isFirstLaunchAfterInstall;
+      state = state.copyWith(
+        isLogin: isLogin,
+        isFirstLaunchAfterInstall: isFirstLaunchAfterInstall,
+      );
     }
   }
 
   void changeIsLogin(bool isLogin) {
     state = state.copyWith(isLogin: isLogin);
+  }
+
+  void changeIsFirstLaunchAfterInstall(
+    bool isFirstLaunchAfterInstall,
+  ) {
+    state = state.copyWith(
+      isFirstLaunchAfterInstall: isFirstLaunchAfterInstall,
+    );
   }
 }

--- a/lib/view/splash_page/splash_page_notifier.freezed.dart
+++ b/lib/view/splash_page/splash_page_notifier.freezed.dart
@@ -17,6 +17,7 @@ final _privateConstructorUsedError = UnsupportedError(
 /// @nodoc
 mixin _$SplashPageState {
   bool? get isLogin => throw _privateConstructorUsedError;
+  bool? get isFirstLaunchAfterInstall => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
   $SplashPageStateCopyWith<SplashPageState> get copyWith =>
@@ -29,7 +30,7 @@ abstract class $SplashPageStateCopyWith<$Res> {
           SplashPageState value, $Res Function(SplashPageState) then) =
       _$SplashPageStateCopyWithImpl<$Res, SplashPageState>;
   @useResult
-  $Res call({bool? isLogin});
+  $Res call({bool? isLogin, bool? isFirstLaunchAfterInstall});
 }
 
 /// @nodoc
@@ -46,11 +47,16 @@ class _$SplashPageStateCopyWithImpl<$Res, $Val extends SplashPageState>
   @override
   $Res call({
     Object? isLogin = freezed,
+    Object? isFirstLaunchAfterInstall = freezed,
   }) {
     return _then(_value.copyWith(
       isLogin: freezed == isLogin
           ? _value.isLogin
           : isLogin // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      isFirstLaunchAfterInstall: freezed == isFirstLaunchAfterInstall
+          ? _value.isFirstLaunchAfterInstall
+          : isFirstLaunchAfterInstall // ignore: cast_nullable_to_non_nullable
               as bool?,
     ) as $Val);
   }
@@ -64,7 +70,7 @@ abstract class _$$SplashPageStateImplCopyWith<$Res>
       __$$SplashPageStateImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({bool? isLogin});
+  $Res call({bool? isLogin, bool? isFirstLaunchAfterInstall});
 }
 
 /// @nodoc
@@ -79,11 +85,16 @@ class __$$SplashPageStateImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? isLogin = freezed,
+    Object? isFirstLaunchAfterInstall = freezed,
   }) {
     return _then(_$SplashPageStateImpl(
       isLogin: freezed == isLogin
           ? _value.isLogin
           : isLogin // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      isFirstLaunchAfterInstall: freezed == isFirstLaunchAfterInstall
+          ? _value.isFirstLaunchAfterInstall
+          : isFirstLaunchAfterInstall // ignore: cast_nullable_to_non_nullable
               as bool?,
     ));
   }
@@ -92,14 +103,16 @@ class __$$SplashPageStateImplCopyWithImpl<$Res>
 /// @nodoc
 
 class _$SplashPageStateImpl implements _SplashPageState {
-  const _$SplashPageStateImpl({this.isLogin});
+  const _$SplashPageStateImpl({this.isLogin, this.isFirstLaunchAfterInstall});
 
   @override
   final bool? isLogin;
+  @override
+  final bool? isFirstLaunchAfterInstall;
 
   @override
   String toString() {
-    return 'SplashPageState(isLogin: $isLogin)';
+    return 'SplashPageState(isLogin: $isLogin, isFirstLaunchAfterInstall: $isFirstLaunchAfterInstall)';
   }
 
   @override
@@ -107,11 +120,15 @@ class _$SplashPageStateImpl implements _SplashPageState {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$SplashPageStateImpl &&
-            (identical(other.isLogin, isLogin) || other.isLogin == isLogin));
+            (identical(other.isLogin, isLogin) || other.isLogin == isLogin) &&
+            (identical(other.isFirstLaunchAfterInstall,
+                    isFirstLaunchAfterInstall) ||
+                other.isFirstLaunchAfterInstall == isFirstLaunchAfterInstall));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, isLogin);
+  int get hashCode =>
+      Object.hash(runtimeType, isLogin, isFirstLaunchAfterInstall);
 
   @JsonKey(ignore: true)
   @override
@@ -122,10 +139,14 @@ class _$SplashPageStateImpl implements _SplashPageState {
 }
 
 abstract class _SplashPageState implements SplashPageState {
-  const factory _SplashPageState({final bool? isLogin}) = _$SplashPageStateImpl;
+  const factory _SplashPageState(
+      {final bool? isLogin,
+      final bool? isFirstLaunchAfterInstall}) = _$SplashPageStateImpl;
 
   @override
   bool? get isLogin;
+  @override
+  bool? get isFirstLaunchAfterInstall;
   @override
   @JsonKey(ignore: true)
   _$$SplashPageStateImplCopyWith<_$SplashPageStateImpl> get copyWith =>

--- a/lib/view/start_stepper_page/components/step_content.dart
+++ b/lib/view/start_stepper_page/components/step_content.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:serene_track/constant/colors.dart';
+import 'package:serene_track/view/start_stepper_page/provider/start_stepper_page_notifier.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class StepContent extends StatelessWidget {
+  const StepContent({
+    super.key,
+    required this.text,
+    required this.urlString,
+    required this.index,
+  });
+
+  final String text;
+  final String urlString;
+  final int index;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            TextButton(
+              style: TextButton.styleFrom(
+                foregroundColor: linkBlue,
+                textStyle: const TextStyle(
+                  decoration: TextDecoration.underline,
+                ),
+              ),
+              child: Text(text),
+              onPressed: () async {
+                final url = Uri.parse(urlString);
+                if (await canLaunchUrl(url)) {
+                  await launchUrl(url);
+                } else {
+                  throw 'リンクが開けません: $url';
+                }
+              },
+            ),
+            Consumer(
+              builder: (context, ref, _) {
+                final checkedList = ref.watch(startStepperPageProvider
+                    .select((value) => value.checkedList));
+                return Checkbox(
+                  checkColor: backGroundColor,
+                  activeColor: linkBlue,
+                  value: checkedList[index],
+                  onChanged: (value) {
+                    ref
+                        .read(startStepperPageProvider.notifier)
+                        .changeCheckedList(index, value!);
+                  },
+                );
+              },
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/view/start_stepper_page/provider/start_stepper_page_notifier.dart
+++ b/lib/view/start_stepper_page/provider/start_stepper_page_notifier.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'start_stepper_page_notifier.freezed.dart';
+
+@freezed
+class StartStepperPageState with _$StartStepperPageState {
+  factory StartStepperPageState({
+    @Default(0) int currentStep,
+    @Default([]) List<bool> checkedList,
+    @Default(false) bool isAllChecked,
+  }) = _StartStepperPageState;
+  StartStepperPageState._();
+}
+
+final startStepperPageProvider = StateNotifierProvider<
+    StartStepperPageStateController,
+    StartStepperPageState>((ref) => StartStepperPageStateController());
+
+class StartStepperPageStateController
+    extends StateNotifier<StartStepperPageState> {
+  StartStepperPageStateController() : super(StartStepperPageState()) {
+    _init();
+  }
+
+  Future<void> _init() async {
+    getInitCheckedList(2);
+  }
+
+  void setIndex(int newIndex) {
+    state = state.copyWith(currentStep: newIndex);
+  }
+
+  void getInitCheckedList(int length) {
+    state = state.copyWith(checkedList: List<bool>.filled(length, false));
+  }
+
+  void changeCheckedList(int index, bool changeValue) {
+    List<bool> checkedList = [
+      for (int i = 0; i < state.checkedList.length; i++)
+        i == index ? changeValue : state.checkedList[i],
+    ];
+    state = state.copyWith(checkedList: checkedList);
+  }
+
+  void setIsAllChecked(bool isAllChecked) {
+    state = state.copyWith(isAllChecked: isAllChecked);
+  }
+}

--- a/lib/view/start_stepper_page/provider/start_stepper_page_notifier.freezed.dart
+++ b/lib/view/start_stepper_page/provider/start_stepper_page_notifier.freezed.dart
@@ -1,0 +1,190 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'start_stepper_page_notifier.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$StartStepperPageState {
+  int get currentStep => throw _privateConstructorUsedError;
+  List<bool> get checkedList => throw _privateConstructorUsedError;
+  bool get isAllChecked => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $StartStepperPageStateCopyWith<StartStepperPageState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $StartStepperPageStateCopyWith<$Res> {
+  factory $StartStepperPageStateCopyWith(StartStepperPageState value,
+          $Res Function(StartStepperPageState) then) =
+      _$StartStepperPageStateCopyWithImpl<$Res, StartStepperPageState>;
+  @useResult
+  $Res call({int currentStep, List<bool> checkedList, bool isAllChecked});
+}
+
+/// @nodoc
+class _$StartStepperPageStateCopyWithImpl<$Res,
+        $Val extends StartStepperPageState>
+    implements $StartStepperPageStateCopyWith<$Res> {
+  _$StartStepperPageStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? currentStep = null,
+    Object? checkedList = null,
+    Object? isAllChecked = null,
+  }) {
+    return _then(_value.copyWith(
+      currentStep: null == currentStep
+          ? _value.currentStep
+          : currentStep // ignore: cast_nullable_to_non_nullable
+              as int,
+      checkedList: null == checkedList
+          ? _value.checkedList
+          : checkedList // ignore: cast_nullable_to_non_nullable
+              as List<bool>,
+      isAllChecked: null == isAllChecked
+          ? _value.isAllChecked
+          : isAllChecked // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$StartStepperPageStateImplCopyWith<$Res>
+    implements $StartStepperPageStateCopyWith<$Res> {
+  factory _$$StartStepperPageStateImplCopyWith(
+          _$StartStepperPageStateImpl value,
+          $Res Function(_$StartStepperPageStateImpl) then) =
+      __$$StartStepperPageStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({int currentStep, List<bool> checkedList, bool isAllChecked});
+}
+
+/// @nodoc
+class __$$StartStepperPageStateImplCopyWithImpl<$Res>
+    extends _$StartStepperPageStateCopyWithImpl<$Res,
+        _$StartStepperPageStateImpl>
+    implements _$$StartStepperPageStateImplCopyWith<$Res> {
+  __$$StartStepperPageStateImplCopyWithImpl(_$StartStepperPageStateImpl _value,
+      $Res Function(_$StartStepperPageStateImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? currentStep = null,
+    Object? checkedList = null,
+    Object? isAllChecked = null,
+  }) {
+    return _then(_$StartStepperPageStateImpl(
+      currentStep: null == currentStep
+          ? _value.currentStep
+          : currentStep // ignore: cast_nullable_to_non_nullable
+              as int,
+      checkedList: null == checkedList
+          ? _value._checkedList
+          : checkedList // ignore: cast_nullable_to_non_nullable
+              as List<bool>,
+      isAllChecked: null == isAllChecked
+          ? _value.isAllChecked
+          : isAllChecked // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$StartStepperPageStateImpl extends _StartStepperPageState {
+  _$StartStepperPageStateImpl(
+      {this.currentStep = 0,
+      final List<bool> checkedList = const [],
+      this.isAllChecked = false})
+      : _checkedList = checkedList,
+        super._();
+
+  @override
+  @JsonKey()
+  final int currentStep;
+  final List<bool> _checkedList;
+  @override
+  @JsonKey()
+  List<bool> get checkedList {
+    if (_checkedList is EqualUnmodifiableListView) return _checkedList;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_checkedList);
+  }
+
+  @override
+  @JsonKey()
+  final bool isAllChecked;
+
+  @override
+  String toString() {
+    return 'StartStepperPageState(currentStep: $currentStep, checkedList: $checkedList, isAllChecked: $isAllChecked)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$StartStepperPageStateImpl &&
+            (identical(other.currentStep, currentStep) ||
+                other.currentStep == currentStep) &&
+            const DeepCollectionEquality()
+                .equals(other._checkedList, _checkedList) &&
+            (identical(other.isAllChecked, isAllChecked) ||
+                other.isAllChecked == isAllChecked));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, currentStep,
+      const DeepCollectionEquality().hash(_checkedList), isAllChecked);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$StartStepperPageStateImplCopyWith<_$StartStepperPageStateImpl>
+      get copyWith => __$$StartStepperPageStateImplCopyWithImpl<
+          _$StartStepperPageStateImpl>(this, _$identity);
+}
+
+abstract class _StartStepperPageState extends StartStepperPageState {
+  factory _StartStepperPageState(
+      {final int currentStep,
+      final List<bool> checkedList,
+      final bool isAllChecked}) = _$StartStepperPageStateImpl;
+  _StartStepperPageState._() : super._();
+
+  @override
+  int get currentStep;
+  @override
+  List<bool> get checkedList;
+  @override
+  bool get isAllChecked;
+  @override
+  @JsonKey(ignore: true)
+  _$$StartStepperPageStateImplCopyWith<_$StartStepperPageStateImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/view/start_stepper_page/start_stepper_page.dart
+++ b/lib/view/start_stepper_page/start_stepper_page.dart
@@ -25,9 +25,10 @@ class StartStepperPage extends ConsumerWidget {
     return Scaffold(
       backgroundColor: backGroundColor,
       appBar: AppBar(
-        foregroundColor: textMainColor,
+        foregroundColor: backGroundColor,
         backgroundColor: appleColor,
         elevation: 0,
+        centerTitle: false,
         flexibleSpace: ClipRect(
           child: BackdropFilter(
             filter: ImageFilter.blur(sigmaX: 5, sigmaY: 5),
@@ -37,148 +38,176 @@ class StartStepperPage extends ConsumerWidget {
         title: const Text(
           'ようこそ',
           style: TextStyle(
-            color: textMainColor,
             fontWeight: FontWeight.bold,
             fontSize: 18,
           ),
         ),
       ),
-      body: Column(
-        children: [
-          Stepper(
-            currentStep: currentStep,
-            onStepCancel: () {
-              if (currentStep != 0) {
+      body: Padding(
+        padding: const EdgeInsets.symmetric(
+          vertical: 24,
+          horizontal: 16,
+        ),
+        child: Column(
+          children: [
+            RichText(
+              text: const TextSpan(
+                children: [
+                  TextSpan(
+                    text: 'Serene Trackへようこそ\n',
+                    style: TextStyle(
+                      fontSize: 22,
+                      fontWeight: FontWeight.w500,
+                      color: appleColor,
+                    ),
+                  ),
+                  TextSpan(
+                    text: '\n',
+                  ),
+                  TextSpan(
+                    text: '利用を開始する前に、利用規約・プライバシーポリシーの合意をお願いいたします。',
+                    style: TextStyle(
+                      color: textMainColor,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Stepper(
+              currentStep: currentStep,
+              onStepCancel: () {
+                if (currentStep != 0) {
+                  ref
+                      .read(startStepperPageProvider.notifier)
+                      .setIndex(currentStep - 1);
+                }
+              },
+              onStepContinue: () {
                 ref
                     .read(startStepperPageProvider.notifier)
-                    .setIndex(currentStep - 1);
-              }
-            },
-            onStepContinue: () {
-              ref
-                  .read(startStepperPageProvider.notifier)
-                  .setIndex(currentStep + 1);
-            },
-            onStepTapped: (int index) {
-              ref.read(startStepperPageProvider.notifier).setIndex(index);
-            },
-            controlsBuilder: (BuildContext context, ControlsDetails details) {
-              return Row(
-                children: [
-                  if (currentStep != 1)
-                    ElevatedButton(
-                      onPressed: details.onStepContinue,
-                      style: ElevatedButton.styleFrom(
-                        textStyle: const TextStyle(
-                          fontWeight: FontWeight.bold,
+                    .setIndex(currentStep + 1);
+              },
+              onStepTapped: (int index) {
+                ref.read(startStepperPageProvider.notifier).setIndex(index);
+              },
+              controlsBuilder: (BuildContext context, ControlsDetails details) {
+                return Row(
+                  children: [
+                    if (currentStep != 1)
+                      ElevatedButton(
+                        onPressed: details.onStepContinue,
+                        style: ElevatedButton.styleFrom(
+                          textStyle: const TextStyle(
+                            fontWeight: FontWeight.bold,
+                          ),
+                          foregroundColor: yellowGreenColor,
+                          backgroundColor: backGroundColor,
+                          side: const BorderSide(
+                            width: 1,
+                            color: yellowGreenColor,
+                          ),
                         ),
-                        foregroundColor: yellowGreenColor,
-                        backgroundColor: backGroundColor,
-                        side: const BorderSide(
-                          width: 1,
-                          color: yellowGreenColor,
-                        ),
+                        child: const Text('次へ'),
                       ),
-                      child: const Text('次へ'),
-                    ),
-                  const SizedBox(width: 8),
-                  if (currentStep != 0)
-                    TextButton(
-                      onPressed: details.onStepCancel,
-                      style: TextButton.styleFrom(
-                        foregroundColor: textMainColor,
-                        backgroundColor: backGroundColor,
-                        side: const BorderSide(
-                          width: 1,
-                          color: textMainColor,
+                    const SizedBox(width: 8),
+                    if (currentStep != 0)
+                      TextButton(
+                        onPressed: details.onStepCancel,
+                        style: TextButton.styleFrom(
+                          foregroundColor: textMainColor,
+                          backgroundColor: backGroundColor,
+                          side: const BorderSide(
+                            width: 1,
+                            color: textMainColor,
+                          ),
                         ),
+                        child: const Text('戻る'),
                       ),
-                      child: const Text('戻る'),
-                    ),
-                ],
-              );
-            },
-            steps: [
-              Step(
-                stepStyle: StepStyle(
-                  color: checkedList[0] == false ? unselectedColor : null,
-                  gradient: checkedList[0] == true
-                      ? const LinearGradient(
-                          colors: [
-                            appleColor,
-                            yellowGreenColor,
-                          ],
-                        )
-                      : null,
+                  ],
+                );
+              },
+              steps: [
+                Step(
+                  stepStyle: StepStyle(
+                    color: checkedList[0] == false ? unselectedColor : null,
+                    gradient: checkedList[0] == true
+                        ? const LinearGradient(
+                            colors: [
+                              appleColor,
+                              yellowGreenColor,
+                            ],
+                          )
+                        : null,
+                  ),
+                  isActive: true,
+                  state: stepState(
+                    step: 0,
+                    currentStep: currentStep,
+                    isChecked: checkedList[0],
+                  ),
+                  title: const Text('利用規約の確認'),
+                  content: const StepContent(
+                    index: 0,
+                    text: '利用規約はこちら',
+                    urlString: kAppTermsUrl,
+                  ),
                 ),
-                isActive: true,
-                state: stepState(
-                  step: 0,
-                  currentStep: currentStep,
-                  isChecked: checkedList[0],
+                Step(
+                  stepStyle: StepStyle(
+                    color: checkedList[1] == false ? unselectedColor : null,
+                    gradient: checkedList[1] == true
+                        ? const LinearGradient(
+                            colors: [
+                              appleColor,
+                              yellowGreenColor,
+                            ],
+                          )
+                        : null,
+                  ),
+                  isActive: true,
+                  state: stepState(
+                    step: 1,
+                    currentStep: currentStep,
+                    isChecked: checkedList[1],
+                  ),
+                  title: const Text('プライバシーポリシーの確認'),
+                  content: const StepContent(
+                    index: 1,
+                    text: 'プライバシーポリシーはこちら',
+                    urlString: kAppPrivacyPolicyUrl,
+                  ),
                 ),
-                title: const Text('利用規約の確認'),
-                content: const StepContent(
-                  index: 0,
-                  text: '利用規約はこちら',
-                  urlString: kAppTermsUrl,
-                ),
-              ),
-              Step(
-                stepStyle: StepStyle(
-                  color: checkedList[1] == false ? unselectedColor : null,
-                  gradient: checkedList[1] == true
-                      ? const LinearGradient(
-                          colors: [
-                            appleColor,
-                            yellowGreenColor,
-                          ],
-                        )
-                      : null,
-                ),
-                isActive: true,
-                state: stepState(
-                  step: 1,
-                  currentStep: currentStep,
-                  isChecked: checkedList[1],
-                ),
-                title: const Text('プライバシーポリシーの確認'),
-                content: const StepContent(
-                  index: 1,
-                  text: 'プライバシーポリシーはこちら',
-                  urlString: kAppPrivacyPolicyUrl,
-                ),
-              ),
-            ],
-          ),
-          ElevatedButton(
-            style: ElevatedButton.styleFrom(
-              textStyle: const TextStyle(
-                fontWeight: FontWeight.bold,
-              ),
-              side: BorderSide(
-                color: allChecked ? appleColor : unselectedColor,
-              ),
-              foregroundColor: appleColor,
-              backgroundColor: backGroundColor,
+              ],
             ),
-            onPressed: allChecked
-                ? () async {
-                    ref
-                        .read(startStepperPageProvider.notifier)
-                        .getInitCheckedList(2);
-                    ref
-                        .read(startStepperPageProvider.notifier)
-                        .setIsAllChecked(allChecked);
-                    await PreferencesManager().setIsFirstLaunchAfterInstall(
-                        isFirstLaunchAfterInstall: false);
-                    if (!context.mounted) return;
-                    context.go(TodoPage.routeLocation);
-                  }
-                : null,
-            child: const Text('はじめる'),
-          ),
-        ],
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                textStyle: const TextStyle(
+                  fontWeight: FontWeight.bold,
+                ),
+                side: BorderSide(
+                  color: allChecked ? appleColor : unselectedColor,
+                ),
+                foregroundColor: appleColor,
+                backgroundColor: backGroundColor,
+              ),
+              onPressed: allChecked
+                  ? () async {
+                      ref
+                          .read(startStepperPageProvider.notifier)
+                          .getInitCheckedList(2);
+                      ref
+                          .read(startStepperPageProvider.notifier)
+                          .setIsAllChecked(allChecked);
+                      await PreferencesManager().setIsFirstLaunchAfterInstall(
+                          isFirstLaunchAfterInstall: false);
+                      if (!context.mounted) return;
+                      context.go(TodoPage.routeLocation);
+                    }
+                  : null,
+              child: const Text('はじめる'),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/view/start_stepper_page/start_stepper_page.dart
+++ b/lib/view/start_stepper_page/start_stepper_page.dart
@@ -1,0 +1,196 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:serene_track/constant/colors.dart';
+import 'package:serene_track/constant/constants.dart';
+import 'package:serene_track/utils/preferences_manager.dart';
+import 'package:serene_track/view/start_stepper_page/components/step_content.dart';
+import 'package:serene_track/view/start_stepper_page/provider/start_stepper_page_notifier.dart';
+import 'package:serene_track/view/todo_page/todo_page.dart';
+
+class StartStepperPage extends ConsumerWidget {
+  const StartStepperPage({super.key});
+  static String get routeName => 'start_stepper_page';
+  static String get routeLocation => '/$routeName';
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final currentStep = ref
+        .watch(startStepperPageProvider.select((value) => value.currentStep));
+    final checkedList = ref
+        .watch(startStepperPageProvider.select((value) => value.checkedList));
+    bool allChecked = checkedList.every((check) => check);
+    return Scaffold(
+      backgroundColor: backGroundColor,
+      appBar: AppBar(
+        foregroundColor: textMainColor,
+        backgroundColor: appleColor,
+        elevation: 0,
+        flexibleSpace: ClipRect(
+          child: BackdropFilter(
+            filter: ImageFilter.blur(sigmaX: 5, sigmaY: 5),
+            child: Container(color: Colors.transparent),
+          ),
+        ),
+        title: const Text(
+          'ようこそ',
+          style: TextStyle(
+            color: textMainColor,
+            fontWeight: FontWeight.bold,
+            fontSize: 18,
+          ),
+        ),
+      ),
+      body: Column(
+        children: [
+          Stepper(
+            currentStep: currentStep,
+            onStepCancel: () {
+              if (currentStep != 0) {
+                ref
+                    .read(startStepperPageProvider.notifier)
+                    .setIndex(currentStep - 1);
+              }
+            },
+            onStepContinue: () {
+              ref
+                  .read(startStepperPageProvider.notifier)
+                  .setIndex(currentStep + 1);
+            },
+            onStepTapped: (int index) {
+              ref.read(startStepperPageProvider.notifier).setIndex(index);
+            },
+            controlsBuilder: (BuildContext context, ControlsDetails details) {
+              return Row(
+                children: [
+                  if (currentStep != 1)
+                    ElevatedButton(
+                      onPressed: details.onStepContinue,
+                      style: ElevatedButton.styleFrom(
+                        textStyle: const TextStyle(
+                          fontWeight: FontWeight.bold,
+                        ),
+                        foregroundColor: yellowGreenColor,
+                        backgroundColor: backGroundColor,
+                        side: const BorderSide(
+                          width: 1,
+                          color: yellowGreenColor,
+                        ),
+                      ),
+                      child: const Text('次へ'),
+                    ),
+                  const SizedBox(width: 8),
+                  if (currentStep != 0)
+                    TextButton(
+                      onPressed: details.onStepCancel,
+                      style: TextButton.styleFrom(
+                        foregroundColor: textMainColor,
+                        backgroundColor: backGroundColor,
+                        side: const BorderSide(
+                          width: 1,
+                          color: textMainColor,
+                        ),
+                      ),
+                      child: const Text('戻る'),
+                    ),
+                ],
+              );
+            },
+            steps: [
+              Step(
+                stepStyle: StepStyle(
+                  color: checkedList[0] == false ? unselectedColor : null,
+                  gradient: checkedList[0] == true
+                      ? const LinearGradient(
+                          colors: [
+                            appleColor,
+                            yellowGreenColor,
+                          ],
+                        )
+                      : null,
+                ),
+                isActive: true,
+                state: stepState(
+                  step: 0,
+                  currentStep: currentStep,
+                  isChecked: checkedList[0],
+                ),
+                title: const Text('利用規約の確認'),
+                content: const StepContent(
+                  index: 0,
+                  text: '利用規約はこちら',
+                  urlString: kAppTermsUrl,
+                ),
+              ),
+              Step(
+                stepStyle: StepStyle(
+                  color: checkedList[1] == false ? unselectedColor : null,
+                  gradient: checkedList[1] == true
+                      ? const LinearGradient(
+                          colors: [
+                            appleColor,
+                            yellowGreenColor,
+                          ],
+                        )
+                      : null,
+                ),
+                isActive: true,
+                state: stepState(
+                  step: 1,
+                  currentStep: currentStep,
+                  isChecked: checkedList[1],
+                ),
+                title: const Text('プライバシーポリシーの確認'),
+                content: const StepContent(
+                  index: 1,
+                  text: 'プライバシーポリシーはこちら',
+                  urlString: kAppPrivacyPolicyUrl,
+                ),
+              ),
+            ],
+          ),
+          ElevatedButton(
+            style: ElevatedButton.styleFrom(
+              textStyle: const TextStyle(
+                fontWeight: FontWeight.bold,
+              ),
+              side: BorderSide(
+                color: allChecked ? appleColor : unselectedColor,
+              ),
+              foregroundColor: appleColor,
+              backgroundColor: backGroundColor,
+            ),
+            onPressed: allChecked
+                ? () async {
+                    ref
+                        .read(startStepperPageProvider.notifier)
+                        .getInitCheckedList(2);
+                    ref
+                        .read(startStepperPageProvider.notifier)
+                        .setIsAllChecked(allChecked);
+                    await PreferencesManager().setIsFirstLaunchAfterInstall(
+                        isFirstLaunchAfterInstall: false);
+                    if (!context.mounted) return;
+                    context.go(TodoPage.routeLocation);
+                  }
+                : null,
+            child: const Text('はじめる'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  StepState stepState({
+    required int step,
+    required int currentStep,
+    required bool isChecked,
+  }) {
+    if (currentStep > step && isChecked) {
+      return StepState.complete;
+    }
+    return StepState.indexed;
+  }
+}

--- a/lib/view/todo_notification_page/todo_notification_page.dart
+++ b/lib/view/todo_notification_page/todo_notification_page.dart
@@ -43,7 +43,7 @@ class TodoNotificationPageState extends ConsumerState<TodoNotificationPage> {
   Future<void> init() async {
     try {
       await initRequestNotificationPermission();
-      await dailyProteinNotifications(todoNotifications);
+      await dailyTodoNotifications(todoNotifications);
     } catch (e) {
       throw (e.toString());
     }


### PR DESCRIPTION
### チケットへのリンク

- #43 

close #43

## ステータス

- タスクの完了

## やったこと

- 利用規約の項目追加

- プライバシーポリシーの項目追加

- 利用規約とプライバシーポリシーを確認するページを作成

  - Stepperウィジェットを使用

  - 初回起動時の新規登録後に遷移する仕様にした
    - 初回起動かを判断するbool値isFirstLaunchAfterInstallをローカルに保存するようにした
  
  - 設定画面からいつでも閲覧できるようにした

## 改善点

- 初回起動時に利用規約とプライバシーポリシーを確認するページに遷移するロジックの部分が正しいか検討